### PR TITLE
added --fsanitize=address to all relevant CMakeFiles

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,46 +10,16 @@ on:
 jobs:
 
   testing:
-    name: py${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: py${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24.04', 'macos-14', 'windows-2022' ]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
 
-      - name: cmake --version
-        run: cmake --version
-
-      - if: matrix.os == 'ubuntu-24.04'
-        name: (ubuntu-24.04) Install Criterion
+      - name: Install Criterion
         run: sudo apt-get install -y libcriterion-dev
-
-      - if: matrix.os == 'macos-14'
-        name: (macos-14) Install Criterion
-        run: brew install criterion
-
-      - if: matrix.os == 'windows-2022'
-        name: (windows-2022) Install Criterion
-        run: |
-          choco install meson -y
-          choco install ninja -y
-          choco install mingw -y
-          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-          refreshenv
-          meson --version
-          ninja --version
-          gcc --version
-          Invoke-WebRequest -Uri https://github.com/Snaipe/Criterion/archive/refs/tags/v2.4.2.tar.gz -OutFile Criterion-2.4.2.tar.gz
-          tar -xvf Criterion-2.4.2.tar.gz
-          cd Criterion-2.4.2
-          meson setup build .
-          meson install -C build
-
-      - if: matrix.os == 'windows-2022'
-        name: (windows-2022) Allow long file names in git checkouts
-        run: git config --system core.longpaths true
 
       - name: Get a copy of the repository contents
         uses: actions/checkout@v4
@@ -70,24 +40,5 @@ jobs:
       - name: Install the template with its testing dependencies
         run: python -m pip install .[testing]
 
-      - if: matrix.os == 'ubuntu-24.04'
-        name: (ubuntu-24.04) Run fuzzy tests
+      - name: Run fuzzy tests
         run: NFUZZY=100 python -m pytest -ra --verbose
-
-      - if: matrix.os == 'macos-14'
-        name: (macos-14) Run fuzzy tests
-        run: CC='gcc-14 -I/opt/homebrew/include -L/opt/homebrew/lib' NFUZZY=100 python -m pytest -ra --verbose
-
-      - if: matrix.os == 'windows-2022'
-        name: (windows-2022) Run fuzzy tests for a selection of C standards
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          $Env:NFUZZY = '100'
-          $Env:C_INCLUDE_PATH='C:\\include'
-          $Env:CC='gcc'
-          $Env:CMAKE_C_STANDARDS='c_std_17,c_std_11,c_std_99,c_std_90'
-          $Env:CMAKE_GENERATOR='Unix Makefiles'
-          $Env:LIBRARY_PATH='C:\\lib'
-          $Env:PATH += ';C:\\bin'
-          python -m pytest -ra --verbose

--- a/template/{%- if case == 'both-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -45,6 +45,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -59,6 +60,12 @@ target_link_libraries(
     PRIVATE
         m
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(
@@ -97,6 +104,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -111,6 +119,12 @@ target_link_libraries(
     tgt_lib_{{ libname }}
     PRIVATE
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-flat-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-flat-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -45,6 +45,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -59,6 +60,12 @@ target_link_libraries(
     PRIVATE
         m
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(
@@ -97,6 +104,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -104,6 +112,12 @@ target_include_directories(
     tgt_lib_{{ libname }}
     PRIVATE
         ${PROJECT_ROOT}/include
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-flat-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-flat-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     PRIVATE
         m
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     tgt_lib_{{ libname }}
     PRIVATE
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     PRIVATE
         m
         tgt_lib_{{ libname }}
+)
+ 
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+       $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -48,6 +49,12 @@ target_include_directories(
     tgt_lib_{{ libname }}
     PRIVATE
         ${PROJECT_ROOT}/include
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'both-nested-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'exe-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'exe-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     tgt_exe_{{ exename }}
     PRIVATE
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'exe-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'exe-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -34,6 +34,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -41,6 +42,12 @@ target_link_libraries(
     tgt_exe_{{ exename }}
     PRIVATE
         m
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'exe-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'exe-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     PRIVATE
         m
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'exe-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'exe-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{exename}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -48,6 +49,12 @@ target_link_libraries(
     tgt_exe_{{ exename }}
     PRIVATE
         m
+)
+
+target_link_options(
+    tgt_exe_{{ exename }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-flat-with-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -45,6 +45,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -59,6 +60,12 @@ target_link_libraries(
     tgt_lib_{{ libname }}
     PRIVATE
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-flat-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-flat-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-flat-wo-external' -%}{{projectname}}{%- endif -%}/src/CMakeLists.txt.jinja
@@ -34,6 +34,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -41,6 +42,12 @@ target_include_directories(
     tgt_lib_{{ libname }}
     PRIVATE
         ${PROJECT_ROOT}/include
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-flat-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-flat-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_libraries(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-nested-with-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -55,6 +56,12 @@ target_link_libraries(
     tgt_lib_{{ libname }}
     PRIVATE
         tgt_lib_their
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-nested-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-nested-with-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-nested-wo-external' -%}{{projectname}}{%- endif -%}/src/{{libname}}/CMakeLists.txt.jinja
@@ -41,6 +41,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -48,6 +49,12 @@ target_include_directories(
     tgt_lib_{{ libname }}
     PRIVATE
         ${PROJECT_ROOT}/include
+)
+
+target_link_options(
+    tgt_lib_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(

--- a/template/{%- if case == 'lib-nested-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
+++ b/template/{%- if case == 'lib-nested-wo-external' -%}{{projectname}}{%- endif -%}/{%- if add_test -%}test{%- endif -%}/{{libname}}/CMakeLists.txt.jinja
@@ -31,6 +31,7 @@ target_compile_options(
         -pedantic
         $<$<CONFIG:Debug>:-g>
         $<$<CONFIG:Debug>:-O0>
+        $<$<CONFIG:Debug>:-fsanitize=address>
         $<$<CONFIG:Release>:-Werror>
 )
 
@@ -45,6 +46,12 @@ target_link_libraries(
     PRIVATE
         criterion
         tgt_lib_{{ libname }}
+)
+
+target_link_options(
+    tgt_exe_test_{{ libname }}
+    PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
 )
 
 target_sources(


### PR DESCRIPTION
 refs #17

This PR adds -fsanitize=address to the `target_compile_options` and `target_link_options` for all variants of the template.